### PR TITLE
Add avito-helper-lite skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Avito credentials
+AVITO_CLIENT_ID=
+AVITO_CLIENT_SECRET=
+AVITO_REFRESH_TOKEN=
+ACCOUNT_ID=
+
+# Database
+DATABASE_URL=postgresql+psycopg2://avito:avito@db:5432/avito_helper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install --no-interaction
+      - name: Black
+        run: poetry run black --check .
+      - name: Mypy
+        run: poetry run mypy avito_helper_lite
+      - name: Pytest
+        run: poetry run pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV POETRY_VERSION=1.6.1
+RUN pip install "poetry==$POETRY_VERSION"
+
+COPY pyproject.toml README.md /app/
+RUN poetry config virtualenvs.create false && \
+    poetry install --no-interaction --only main
+
+COPY . /app
+
+RUN playwright install --with-deps chromium
+
+CMD ["python", "-m", "avito_helper_lite.app.gui.main_window"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# Avito_exe
+# Avito Helper Lite
+
+Skeleton application to collect stats, track competitors and manage descriptions on Avito.
+
+## Requirements
+- Docker and docker-compose
+
+## Quick start
+```bash
+cp .env.example .env
+# fill credentials
+
+# build and run services
+docker-compose up --build
+```
+The GUI window will appear from the `app` container. Use it to update API keys or descriptions.
+
+## Development
+
+Install Poetry and Python 3.12.
+```bash
+poetry install
+poetry run python -m avito_helper_lite.app.gui.main_window
+```
+
+Run formatting and tests:
+```bash
+poetry run black .
+poetry run mypy avito_helper_lite
+pytest
+```
+
+Database migrations managed by Alembic:
+```bash
+poetry run alembic revision --autogenerate -m "message"
+poetry run alembic upgrade head
+```
+
+

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = %(DATABASE_URL)s
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from avito_helper_lite.app import models
+
+config = context.config
+fileConfig(config.config_file_name)
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = models.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=DATABASE_URL, target_metadata=target_metadata, literal_binds=True
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,45 @@
+"""Initial tables"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "item_stats",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("item_id", sa.String, nullable=False),
+        sa.Column("date", sa.Date, nullable=False),
+        sa.Column("views", sa.Integer, nullable=False),
+    )
+    op.create_table(
+        "competitor_items",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("item_id", sa.String, nullable=False),
+        sa.Column("seller_id", sa.String, nullable=False),
+        sa.Column("price", sa.Integer, nullable=False),
+        sa.Column("last_seen", sa.DateTime, nullable=False),
+        sa.Column("views", sa.Integer),
+    )
+    op.create_table(
+        "competitor_views",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "item_id", sa.Integer, sa.ForeignKey("competitor_items.id"), nullable=False
+        ),
+        sa.Column("date", sa.DateTime, nullable=False),
+        sa.Column("views", sa.Integer, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("competitor_views")
+    op.drop_table("competitor_items")
+    op.drop_table("item_stats")

--- a/avito_helper_lite/app/__init__.py
+++ b/avito_helper_lite/app/__init__.py
@@ -1,0 +1,3 @@
+"""Avito Helper Lite package."""
+
+__all__ = ["models", "core", "services", "gui"]

--- a/avito_helper_lite/app/core/avito_client.py
+++ b/avito_helper_lite/app/core/avito_client.py
@@ -1,0 +1,70 @@
+"""Avito API client."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import Any
+
+import requests
+from requests import Response
+
+logger = logging.getLogger(__name__)
+
+
+class AvitoClient:
+    BASE_URL = "https://api.avito.ru"
+    OAUTH_URL = "https://api.avito.ru/token"
+
+    def __init__(self, client_id: str, client_secret: str, refresh_token: str) -> None:
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.refresh_token = refresh_token
+        self.access_token: str | None = None
+        self.token_expiry: dt.datetime | None = None
+
+    def _refresh_token(self) -> None:
+        logger.info("Refreshing access token")
+        resp = requests.post(
+            self.OAUTH_URL,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "refresh_token": self.refresh_token,
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        self.access_token = data["access_token"]
+        self.token_expiry = dt.datetime.utcnow() + dt.timedelta(
+            seconds=data.get("expires_in", 3600)
+        )
+
+    def _auth_headers(self) -> dict[str, str]:
+        if (
+            not self.access_token
+            or not self.token_expiry
+            or dt.datetime.utcnow() >= self.token_expiry
+        ):
+            self._refresh_token()
+        return {"Authorization": f"Bearer {self.access_token}"}
+
+    def request(self, method: str, path: str, **kwargs: Any) -> Response:
+        url = f"{self.BASE_URL}{path}"
+        headers = kwargs.pop("headers", {})
+        headers.update(self._auth_headers())
+        resp = requests.request(method, url, headers=headers, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    def get_items_stats(self, account_id: str) -> list[dict[str, Any]]:
+        resp = self.request("POST", f"/stats/v1/accounts/{account_id}/items")
+        return resp.json().get("result", [])
+
+    def update_description(self, account_id: str, item_id: str, text: str) -> None:
+        self.request(
+            "PUT",
+            f"/core/v1/accounts/{account_id}/items/{item_id}",
+            json={"description": text},
+        )

--- a/avito_helper_lite/app/gui/main_window.py
+++ b/avito_helper_lite/app/gui/main_window.py
@@ -1,0 +1,79 @@
+"""Main application window."""
+
+from __future__ import annotations
+
+import os
+import threading
+
+import PySimpleGUI as sg
+from dotenv import load_dotenv
+
+from ..core.avito_client import AvitoClient
+from ..services.description_service import DescriptionService
+from ..scheduler import create_scheduler
+
+
+def main() -> None:
+    load_dotenv()
+    layout = [
+        [
+            sg.Text("Client ID"),
+            sg.Input(key="CLIENT_ID", default_text=os.getenv("AVITO_CLIENT_ID", "")),
+        ],
+        [
+            sg.Text("Client Secret"),
+            sg.Input(
+                key="CLIENT_SECRET", default_text=os.getenv("AVITO_CLIENT_SECRET", "")
+            ),
+        ],
+        [
+            sg.Text("Refresh Token"),
+            sg.Input(
+                key="REFRESH_TOKEN", default_text=os.getenv("AVITO_REFRESH_TOKEN", "")
+            ),
+        ],
+        [
+            sg.Text("Account ID"),
+            sg.Input(key="ACCOUNT_ID", default_text=os.getenv("ACCOUNT_ID", "")),
+        ],
+        [sg.Text("Description")],
+        [sg.Multiline(size=(60, 10), key="DESC")],
+        [sg.Button("Save Keys"), sg.Button("Update Description"), sg.Button("Exit")],
+    ]
+
+    window = sg.Window("Avito Helper Lite", layout)
+
+    scheduler = create_scheduler()
+    scheduler.start()
+
+    client: AvitoClient | None = None
+    desc_service: DescriptionService | None = None
+
+    while True:
+        event, values = window.read()
+        if event in (sg.WIN_CLOSED, "Exit"):
+            break
+        if event == "Save Keys":
+            os.environ.update(
+                {
+                    "AVITO_CLIENT_ID": values["CLIENT_ID"],
+                    "AVITO_CLIENT_SECRET": values["CLIENT_SECRET"],
+                    "AVITO_REFRESH_TOKEN": values["REFRESH_TOKEN"],
+                    "ACCOUNT_ID": values["ACCOUNT_ID"],
+                }
+            )
+            client = AvitoClient(
+                values["CLIENT_ID"], values["CLIENT_SECRET"], values["REFRESH_TOKEN"]
+            )
+            desc_service = DescriptionService(client, values["ACCOUNT_ID"])
+            sg.popup("Saved")
+        if event == "Update Description" and desc_service:
+            text = values["DESC"]
+            threading.Thread(target=desc_service.update_all_items, args=(text,)).start()
+
+    scheduler.shutdown()
+    window.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/avito_helper_lite/app/models.py
+++ b/avito_helper_lite/app/models.py
@@ -1,0 +1,49 @@
+"""Database models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class ItemStat(Base):
+    __tablename__ = "item_stats"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    item_id: Mapped[str]
+    date: Mapped[datetime]
+    views: Mapped[int]
+
+
+class CompetitorItem(Base):
+    __tablename__ = "competitor_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    item_id: Mapped[str]
+    seller_id: Mapped[str]
+    price: Mapped[int]
+    last_seen: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    views: Mapped[int] | None
+
+    history: Mapped[list[CompetitorView]] = relationship(
+        "CompetitorView", back_populates="item", cascade="all, delete-orphan"
+    )
+
+
+class CompetitorView(Base):
+    __tablename__ = "competitor_views"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    item_id: Mapped[int] = mapped_column(ForeignKey("competitor_items.id"))
+    date: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    views: Mapped[int]
+
+    item: Mapped[CompetitorItem] = relationship(
+        "CompetitorItem", back_populates="history"
+    )

--- a/avito_helper_lite/app/scheduler.py
+++ b/avito_helper_lite/app/scheduler.py
@@ -1,0 +1,48 @@
+"""Scheduler configuration."""
+
+from __future__ import annotations
+
+import os
+from datetime import time
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+
+from .core.avito_client import AvitoClient
+from .services.competitor_service import CompetitorService
+from .services.stats_service import StatsService
+
+
+def create_scheduler() -> BackgroundScheduler:
+    db_url = os.getenv("DATABASE_URL", "")
+    jobstores = {"default": SQLAlchemyJobStore(url=db_url)}
+    scheduler = BackgroundScheduler(jobstores=jobstores, timezone="Europe/Moscow")
+
+    client = AvitoClient(
+        os.getenv("AVITO_CLIENT_ID", ""),
+        os.getenv("AVITO_CLIENT_SECRET", ""),
+        os.getenv("AVITO_REFRESH_TOKEN", ""),
+    )
+    account_id = os.getenv("ACCOUNT_ID", "")
+
+    stats_service = StatsService(client, account_id, db_url)
+    competitor_service = CompetitorService(db_url)
+
+    scheduler.add_job(
+        stats_service.collect_daily_views,
+        "cron",
+        hour=23,
+        minute=0,
+        id="collect_daily_views",
+        replace_existing=True,
+    )
+    scheduler.add_job(
+        competitor_service.track,
+        "cron",
+        hour=0,
+        minute=30,
+        id="competitor_tracker",
+        replace_existing=True,
+    )
+
+    return scheduler

--- a/avito_helper_lite/app/services/competitor_service.py
+++ b/avito_helper_lite/app/services/competitor_service.py
@@ -1,0 +1,62 @@
+"""Service to track competitor items."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from playwright.sync_api import sync_playwright
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from ..models import Base, CompetitorItem, CompetitorView
+
+SEARCH_URL = (
+    "https://www.avito.ru/voronezhskaya_oblast/mebel_i_interer/kuhonnye_garnitury/"
+    "kukhni-ASgBAgICAkRazk_W6hKMso0D?cd=1&f=ASgBAgECAkRazk_W6hKMso0DAUXGmgwVeyJmcm9tIjo1MDAwMCwidG8iOjB9&q=кухни+на+заказ"
+)
+
+
+class CompetitorService:
+    def __init__(self, db_url: str) -> None:
+        self.engine = create_engine(db_url)
+        Base.metadata.create_all(self.engine)
+
+    def track(self) -> None:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+            page.goto(SEARCH_URL)
+            page.wait_for_load_state("networkidle")
+
+            items = page.query_selector_all("div[data-marker='item']")[:20]
+            data = []
+            for it in items:
+                item_id = it.get_attribute("data-item-id")
+                seller_id = it.get_attribute("data-owner-id") or ""
+                price_text = it.query_selector(
+                    "span[data-marker='item-price']"
+                ).inner_text()
+                price = (
+                    int("".join(filter(str.isdigit, price_text))) if price_text else 0
+                )
+                views = None
+                data.append((item_id, seller_id, price, views))
+            browser.close()
+
+        with Session(self.engine) as session:
+            for item_id, seller_id, price, views in data:
+                comp_item = session.scalar(
+                    select(CompetitorItem).where(CompetitorItem.item_id == item_id)
+                )
+                if not comp_item:
+                    comp_item = CompetitorItem(
+                        item_id=item_id, seller_id=seller_id, price=price, views=views
+                    )
+                    session.add(comp_item)
+                    session.flush()
+                else:
+                    comp_item.price = price
+                    comp_item.last_seen = dt.datetime.utcnow()
+                    comp_item.views = views
+                session.add(CompetitorView(item_id=comp_item.id, views=views or 0))
+            session.commit()

--- a/avito_helper_lite/app/services/description_service.py
+++ b/avito_helper_lite/app/services/description_service.py
@@ -1,0 +1,16 @@
+"""Service for description synchronization."""
+
+from __future__ import annotations
+
+from ..core.avito_client import AvitoClient
+
+
+class DescriptionService:
+    def __init__(self, client: AvitoClient, account_id: str) -> None:
+        self.client = client
+        self.account_id = account_id
+
+    def update_all_items(self, text: str) -> None:
+        items = self.client.get_items_stats(self.account_id)
+        for item in items:
+            self.client.update_description(self.account_id, str(item["item_id"]), text)

--- a/avito_helper_lite/app/services/stats_service.py
+++ b/avito_helper_lite/app/services/stats_service.py
@@ -1,0 +1,32 @@
+"""Service for collecting daily views."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Iterable
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from ..core.avito_client import AvitoClient
+from ..models import Base, ItemStat
+
+
+class StatsService:
+    def __init__(self, client: AvitoClient, account_id: str, db_url: str) -> None:
+        self.client = client
+        self.account_id = account_id
+        self.engine = create_engine(db_url)
+        Base.metadata.create_all(self.engine)
+
+    def collect_daily_views(self) -> None:
+        items = self.client.get_items_stats(self.account_id)
+        with Session(self.engine) as session:
+            for item in items:
+                stat = ItemStat(
+                    item_id=str(item["item_id"]),
+                    date=dt.datetime.utcnow().date(),
+                    views=item["counters"]["views_total"],
+                )
+                session.add(stat)
+            session.commit()

--- a/avito_helper_lite/tests/test_dummy.py
+++ b/avito_helper_lite/tests/test_dummy.py
@@ -1,0 +1,2 @@
+def test_dummy() -> None:
+    assert True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: avito
+      POSTGRES_PASSWORD: avito
+      POSTGRES_DB: avito_helper
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  browser:
+    image: mcr.microsoft.com/playwright:v1.41.2-jammy
+    tty: true
+
+  app:
+    build: .
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - browser
+    volumes:
+      - .:/app
+    command: ["python", "-m", "avito_helper_lite.app.gui.main_window"]
+
+volumes:
+  postgres_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[tool.poetry]
+name = "avito-helper-lite"
+version = "0.1.0"
+description = "Lightweight helper for Avito"
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+PySimpleGUI = "*"
+SQLAlchemy = "^2.0"
+psycopg2-binary = "*"
+requests = "*"
+APScheduler = "*"
+playwright = "*"
+python-dotenv = "*"
+
+[tool.poetry.group.dev.dependencies]
+black = "*"
+mypy = "*"
+pytest = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- initialize skeleton for avito-helper-lite
- add Poetry configuration and Docker setup
- implement Avito API client, services, scheduler, and GUI
- provide Alembic migrations and CI workflow
- include basic tests and documentation

## Testing
- `black .`
- `mypy avito_helper_lite --ignore-missing-imports`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa25bb8cc8327b6c31f196d667301